### PR TITLE
Fixed assumption that Drupal is bootstrapped.

### DIFF
--- a/contenttokens.php
+++ b/contenttokens.php
@@ -209,7 +209,7 @@ function contenttokens_civicrm_tokens( &$tokens ){
 				LEFT JOIN $revision_tb rv ON t1.vid = rv.vid
 				ORDER BY t1.created DESC ";	
 			}else if( $partial_token == 'feed'){
-			   if( module_exists( "aggregator")){ 
+			   if(function_exists('module_exists') && module_exists( "aggregator")){
 			
 			//  substring( description, 1, 250) as teasertest
 			   $sql = "SELECT title as title, link as full_url, DATE( FROM_UNIXTIME( timestamp )) as formatted_create_date
@@ -270,7 +270,7 @@ function contenttokens_civicrm_tokens( &$tokens ){
 				ORDER BY t1.created DESC ";
 			
 			}else if($partial_token == 'feed' ){
-			  if( module_exists( "aggregator")){ 
+			  if(function_exists('module_exists') && module_exists( "aggregator")){
 			    // substring( description, 1, 250) as teasertest
 				 $sql = "SELECT title as title, link as full_url , DATE( FROM_UNIXTIME( timestamp )) as formatted_create_date
 			           FROM $cms_db.aggregator_item where fid = $feed_id 
@@ -440,7 +440,7 @@ function contenttokens_civicrm_tokens( &$tokens ){
         // print "<br><br>";
 	// print_r( $config) ; 
 	if ($config->userFramework=="Drupal" || $config->userFramework=="Drupal6"){
-	  if( module_exists( "aggregator")){ 
+	  if(function_exists('module_exists') && module_exists( "aggregator")){
 	
 		    // get all aggregator feeds that are used 
 		    $sql = "SELECT fid as feed_id, title as feed_title FROM $cms_db.aggregator_feed";


### PR DESCRIPTION
While troubleshooting a problem with a client's PayPal IPN integration, I discovered that this extension is causing a PHP fatal error which results in CiviCRM responding to the IPN with a 500.

> PHP Fatal error: Call to undefined function module_exists() in /REDACTED/com.pogstone.contenttokens/contenttokens.php on line 443

Note that `module_exists()` is a Drupal function. I understand this extension is expected to be cross-platform-installable, so I was a little surprised to find CMS-specific code here. I did not do enough inspection of the code to see what kind of CMS-sniffing the extension does to determine whether or not it is safe to call this function, but this is rather beside the point.

Apparently, when CiviCRM is bootstrapped to handle IPN notifications, some hook is invoked which causes this extension to be loaded. At the same time, in order to maximize efficiency, CiviCRM does not bootstrap the CMS, so the `module_exists()` function is not available in the IPN handler, even in Drupal instances.

This PR simply adds a check that the function exists before trying to invoke it.